### PR TITLE
Add title override

### DIFF
--- a/markdown_gfm_admonition.py
+++ b/markdown_gfm_admonition.py
@@ -1,11 +1,11 @@
 import re
 from typing import List, Optional
+from xml.etree.ElementTree import Element, SubElement
 
+from markdown.blockparser import BlockParser
+from markdown.blockprocessors import BlockProcessor
 from markdown.core import Markdown
 from markdown.extensions import Extension
-from markdown.blockprocessors import BlockProcessor
-from markdown.blockparser import BlockParser
-from xml.etree.ElementTree import Element, SubElement
 
 __all__ = ["GfmAdmonitionExtension", "GfmAdmonitionProcessor", "makeExtension"]
 
@@ -14,18 +14,21 @@ class GfmAdmonitionExtension(Extension):
     def extendMarkdown(self, md: Markdown) -> None:
         md.registerExtension(self)
         md.parser.blockprocessors.register(
-            GfmAdmonitionProcessor(md.parser),
-            "gfm_admonition",
-            105
+            GfmAdmonitionProcessor(md.parser), "gfm_admonition", 105
         )
 
 
 class GfmAdmonitionProcessor(BlockProcessor):
-    PATTERN = re.compile(r"""
+    PATTERN = re.compile(
+        r"""
         ^ \s*
         \\? \[ ! ( NOTE | TIP | IMPORTANT | WARNING | CAUTION ) \\? \]
+        [ ]? (.*)
+        (?: [ ]+ (.*) )?
         (?: $ | (?: [ ] [ ] )? \n )
-    """, re.VERBOSE | re.IGNORECASE)
+    """,
+        re.VERBOSE | re.IGNORECASE,
+    )
 
     def __init__(self, parser: BlockParser):
         super().__init__(parser)
@@ -40,13 +43,15 @@ class GfmAdmonitionProcessor(BlockProcessor):
         if not blocks:
             return False
         match = self.PATTERN.match(blocks[0])
-        blocks[0] = blocks[0][match.end():]
+        blocks[0] = blocks[0][match.end() :]
         type_ = match.group(1).lower()
+        override_title = match.group(2)
         parent.tag = "div"
         parent.set("class", "admonition " + type_)
         title = SubElement(parent, "p")
         title.set("class", "admonition-title")
-        title.text = type_.capitalize()
+        title.text = override_title if override_title else type_.capitalize()
+        title.text = override_title if override_title else type_.capitalize()
         self.parser.parseBlocks(parent, blocks)
         blocks.clear()
         return True

--- a/test.py
+++ b/test.py
@@ -9,11 +9,13 @@ from markdown_gfm_admonition import GfmAdmonitionExtension
 
 class GfmAdmonitionTestCase(TestCase):
     def setUp(self) -> None:
-        ext = choice([
-            GfmAdmonitionExtension(),
-            "markdown_gfm_admonition:GfmAdmonitionExtension",
-            "gfm_admonition",
-        ])
+        ext = choice(
+            [
+                GfmAdmonitionExtension(),
+                "markdown_gfm_admonition:GfmAdmonitionExtension",
+                "gfm_admonition",
+            ]
+        )
         self.md = Markdown(extensions=[ext])
 
     def assertHtmlEqual(self, expected: str, actual: str):
@@ -45,7 +47,7 @@ class GfmAdmonitionTestCase(TestCase):
             '<hr></hr><div class="admonition note"><p class="admonition-title">'
             "Note</p><p>Highlights information that users should take into "
             "account,\neven when skimming.</p></div>",
-            result
+            result,
         )
 
     def testTip(self):
@@ -61,20 +63,18 @@ class GfmAdmonitionTestCase(TestCase):
             "<p>Optional information to help a user be more successful.</p>"
             "</div><hr></hr><blockquote><p>This is not an admonition block.</p>"
             "</blockquote>",
-            result
+            result,
         )
 
     def testImportant(self):
         result = self.md.convert(
-            "> [!IMPORTANT]\n"
-            ">\n"
-            "> Crucial information necessary for users to succeed."
+            "> [!IMPORTANT]\n>\n> Crucial information necessary for users to succeed."
         )
         self.assertHtmlEqual(
             '<div class="admonition important"><p class="admonition-title">'
             "Important</p><p>Crucial information necessary for users to "
             "succeed.</p></div>",
-            result
+            result,
         )
 
     def testWarning(self):
@@ -88,20 +88,18 @@ class GfmAdmonitionTestCase(TestCase):
             '<div class="admonition warning"><p class="admonition-title">'
             "Warning</p><p>Critical content demanding immediate user attention "
             "due to potential risks.</p></div>",
-            result
+            result,
         )
 
     def testCuation(self):
         result = self.md.convert(
-            "> [!CAUTION]\n"
-            "> \n"
-            "> Negative potential consequences of an action."
+            "> [!CAUTION]\n> \n> Negative potential consequences of an action."
         )
         self.assertHtmlEqual(
             '<div class="admonition caution"><p class="admonition-title">'
             "Caution</p><p>Negative potential consequences of an action.</p>"
             "</div>",
-            result
+            result,
         )
 
     def testEscapedBrackets(self):
@@ -117,29 +115,33 @@ class GfmAdmonitionTestCase(TestCase):
             "<p>Optional information to help a user be more successful.</p>"
             "</div><hr></hr><blockquote><p>This is not an admonition block.</p>"
             "</blockquote>",
-            result
+            result,
         )
 
     def testLowercaseNote(self):
-        result = self.md.convert(
-            "> [!note]\n"
-            "> This is a lowercase note.\n"
-        )
+        result = self.md.convert("> [!note]\n> This is a lowercase note.\n")
         self.assertHtmlEqual(
             '<div class="admonition note"><p class="admonition-title">'
             "Note</p><p>This is a lowercase note.</p></div>",
-            result
+            result,
         )
 
     def testMixedCaseTip(self):
-        result = self.md.convert(
-            "> [!Tip]\n"
-            "> This is a mixed case tip.\n"
-        )
+        result = self.md.convert("> [!Tip]\n> This is a mixed case tip.\n")
         self.assertHtmlEqual(
             '<div class="admonition tip"><p class="admonition-title">'
             "Tip</p><p>This is a mixed case tip.</p></div>",
-            result
+            result,
+        )
+
+    def testTitleOverride(self):
+        result = self.md.convert(
+            "> [!NOTE] My Custom Title\n> This is a note with a custom title.\n"
+        )
+        self.assertHtmlEqual(
+            '<div class="admonition note"><p class="admonition-title">'
+            "My Custom Title</p><p>This is a note with a custom title.</p></div>",
+            result,
         )
 
 


### PR DESCRIPTION
This PR adds a title override functionality to the extension.

For example:
```
> [!NOTE] TL;DR
> This is a TL;DR section. Read further for the full details.
```

Will create a NOTE admonition, but apply the "TL;DR" title.